### PR TITLE
Install media directory

### DIFF
--- a/ubuntu/debian/libgz-sim.install
+++ b/ubuntu/debian/libgz-sim.install
@@ -2,5 +2,6 @@ usr/lib/*/*.so.*
 usr/share/*/*-*[0-99]/*.config
 usr/share/*/*-*[0-99]/gui/*
 usr/share/*/*-*[0-99]/worlds/*
+usr/share/*/*-*[0-99]/media/*
 obj-*/gz-logo[0-99].svg usr/share/icons/hicolor/scalable/apps/
 obj-*/gz-sim[0-99].desktop usr/share/applications/


### PR DESCRIPTION
gazebosim/gz-sim#2313 adds a file to usr/share/gz/gz-sim7/media, this change prevents CI warnings as per gazebo-release/gz-sim8-release#5